### PR TITLE
adding altID parameter to refresh endpoint and removing productName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </description>
     <url>https://github.com/Hygieia/${repository.name}</url>
     <packaging>jar</packaging>
-    <version>1.3.4-SNAPSHOT</version>
+    <version>1.3.5-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -52,7 +52,7 @@
         <repository.name>hygieia-whitesource-collector</repository.name>
         <apache.rat.plugin.version>0.13</apache.rat.plugin.version>
         <bc.version>3.0.1</bc.version>
-        <com.capitalone.dashboard.core.version>3.15.38</com.capitalone.dashboard.core.version>
+        <com.capitalone.dashboard.core.version>3.15.41</com.capitalone.dashboard.core.version>
         <tomcat.version>8.5.70</tomcat.version>
         <commons.io.version>2.8.0</commons.io.version>
         <commons.lang.version>3.8.1</commons.lang.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>whitesource-collector</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>
-        Whitesource Collector Microservice collecting stats from Whitesource
+        Whitesource Collector Microservice collecting stats from Whitesource/Mend
     </description>
     <url>https://github.com/Hygieia/${repository.name}</url>
     <packaging>jar</packaging>

--- a/src/main/java/com/capitalone/dashboard/collector/DefaultWhiteSourceClient.java
+++ b/src/main/java/com/capitalone/dashboard/collector/DefaultWhiteSourceClient.java
@@ -680,10 +680,10 @@ public class DefaultWhiteSourceClient implements WhiteSourceClient {
         Map<String, Object> options = getOptions(orgName, projectToken);
         Iterable<CollectorItem> collectorItems = new ArrayList<>();
 
-        if (Objects.nonNull(projectToken)) {
+        if (StringUtils.isNotEmpty(projectToken)) {
             collectorItems = collectorItemRepository.findAllByOptionMapAndCollectorIdsIn(options, Stream.of(collector.getId()).collect(Collectors.toList()));
         }
-        else if (Objects.nonNull(altIdentifier)) {
+        else if (StringUtils.isNotEmpty(altIdentifier)) {
             collectorItems = collectorItemRepository.findAllByOptionMapCollectorIdAndAltId(options, collector.getId(), altIdentifier);
         }
 

--- a/src/main/java/com/capitalone/dashboard/collector/DefaultWhiteSourceClient.java
+++ b/src/main/java/com/capitalone/dashboard/collector/DefaultWhiteSourceClient.java
@@ -413,16 +413,10 @@ public class DefaultWhiteSourceClient implements WhiteSourceClient {
         return projectVitalMap;
     }
 
-    /**
-     * Refresh project on demand using org level project vitals
-     *
-     * @param orgName Whitesource Org
-     * @param projectToken Whitesource Project Token
-     *
-     */
+
     @Override
-    public void refresh (String orgName, String projectToken, String altIdentifier){
-        List<WhiteSourceComponent> components = getWhiteSourceComponents(orgName, projectToken, altIdentifier);
+    public void refresh (String projectToken, String altIdentifier){
+        List<WhiteSourceComponent> components = getWhiteSourceComponents(projectToken, altIdentifier);
         if(!components.isEmpty()) {
             components.forEach(component -> {
                 LibraryPolicyResult libraryPolicyResult = getProjectAlerts(component, null, whiteSourceSettings.getWhiteSourceServerSettings().get(0));
@@ -675,7 +669,7 @@ public class DefaultWhiteSourceClient implements WhiteSourceClient {
     }
 
 
-    public List<WhiteSourceComponent> getWhiteSourceComponents(String orgName, String projectToken, String altIdentifier) {
+    public List<WhiteSourceComponent> getWhiteSourceComponents(String projectToken, String altIdentifier) {
         Collector collector = collectorRepository.findByName(Constants.WHITE_SOURCE);
         Iterable<CollectorItem> collectorItems = new ArrayList<>();
 

--- a/src/main/java/com/capitalone/dashboard/collector/DefaultWhiteSourceClient.java
+++ b/src/main/java/com/capitalone/dashboard/collector/DefaultWhiteSourceClient.java
@@ -417,19 +417,17 @@ public class DefaultWhiteSourceClient implements WhiteSourceClient {
     @Override
     public void refresh (String projectToken, String altIdentifier){
         List<WhiteSourceComponent> components = getWhiteSourceComponents(projectToken, altIdentifier);
-        if(!components.isEmpty()) {
-            components.forEach(component -> {
-                LibraryPolicyResult libraryPolicyResult = getProjectAlerts(component, null, whiteSourceSettings.getWhiteSourceServerSettings().get(0));
-                if (Objects.nonNull(libraryPolicyResult)) {
-                    libraryPolicyResult.setCollectorItemId(component.getId());
-                    LibraryPolicyResult libraryPolicyResultExisting = getLibraryPolicyData(component, libraryPolicyResult);
-                    if (Objects.nonNull(libraryPolicyResultExisting)) {
-                        libraryPolicyResult.setId(libraryPolicyResultExisting.getId());
-                    }
-                    libraryPolicyResultsRepository.save(libraryPolicyResult);
+        components.forEach(component -> {
+            LibraryPolicyResult libraryPolicyResult = getProjectAlerts(component, null, whiteSourceSettings.getWhiteSourceServerSettings().get(0));
+            if (Objects.nonNull(libraryPolicyResult)) {
+                libraryPolicyResult.setCollectorItemId(component.getId());
+                LibraryPolicyResult libraryPolicyResultExisting = getLibraryPolicyData(component, libraryPolicyResult);
+                if (Objects.nonNull(libraryPolicyResultExisting)) {
+                    libraryPolicyResult.setId(libraryPolicyResultExisting.getId());
                 }
-            });
-        }
+                libraryPolicyResultsRepository.save(libraryPolicyResult);
+            }
+        });
     }
 
     ////////////////////////////////////////////       Helper and private methods below /////////////////////////////////////////

--- a/src/main/java/com/capitalone/dashboard/collector/DefaultWhiteSourceClient.java
+++ b/src/main/java/com/capitalone/dashboard/collector/DefaultWhiteSourceClient.java
@@ -677,14 +677,13 @@ public class DefaultWhiteSourceClient implements WhiteSourceClient {
 
     public List<WhiteSourceComponent> getWhiteSourceComponents(String orgName, String projectToken, String altIdentifier) {
         Collector collector = collectorRepository.findByName(Constants.WHITE_SOURCE);
-        Map<String, Object> options = getOptions(orgName, projectToken);
         Iterable<CollectorItem> collectorItems = new ArrayList<>();
 
         if (StringUtils.isNotEmpty(projectToken)) {
-            collectorItems = collectorItemRepository.findAllByOptionMapAndCollectorIdsIn(options, Stream.of(collector.getId()).collect(Collectors.toList()));
+            collectorItems = whiteSourceComponentRepository.findByCollectorIdAndProjectToken(collector.getId(), projectToken);
         }
         else if (StringUtils.isNotEmpty(altIdentifier)) {
-            collectorItems = collectorItemRepository.findAllByOptionMapCollectorIdAndAltId(options, collector.getId(), altIdentifier);
+            collectorItems = whiteSourceComponentRepository.findByCollectorIdAndAltIdentifier(collector.getId(), altIdentifier);
         }
 
 
@@ -707,13 +706,6 @@ public class DefaultWhiteSourceClient implements WhiteSourceClient {
         whiteSourceComponent.setEnabled(collectorItem.isEnabled());
         whiteSourceComponent.setLastUpdated(collectorItem.getLastUpdated());
         return whiteSourceComponent;
-    }
-
-    private static Map<String, Object> getOptions(String orgName, String projectToken) {
-        Map<String, Object> options = new HashMap<>();
-        options.put(Constants.ORG_NAME, orgName);
-        if(Objects.nonNull(projectToken)){options.put(Constants.PROJECT_TOKEN, projectToken);}
-        return options;
     }
 
 

--- a/src/main/java/com/capitalone/dashboard/collector/WhiteSourceClient.java
+++ b/src/main/java/com/capitalone/dashboard/collector/WhiteSourceClient.java
@@ -23,5 +23,5 @@ public interface WhiteSourceClient {
     Map<String, WhiteSourceProjectVital> getOrgProjectVitals(WhitesourceOrg whitesourceOrg, WhiteSourceServerSettings whiteSourceServerSettings) throws HygieiaException;
     Set<String> getAffectedProjectsForOrganization(WhitesourceOrg whitesourceOrg, long historyTimestamp, WhiteSourceServerSettings serverSettings) throws ExecutionException, InterruptedException;
     List<WhiteSourceComponent> getAllProjectsForProduct(WhitesourceOrg whitesourceOrg, WhiteSourceProduct product, WhiteSourceServerSettings serverSettings);
-    void refresh (String orgName, String projectToken, String altIdentifier);
+    void refresh (String projectToken, String altIdentifier);
 }

--- a/src/main/java/com/capitalone/dashboard/collector/WhiteSourceClient.java
+++ b/src/main/java/com/capitalone/dashboard/collector/WhiteSourceClient.java
@@ -23,5 +23,5 @@ public interface WhiteSourceClient {
     Map<String, WhiteSourceProjectVital> getOrgProjectVitals(WhitesourceOrg whitesourceOrg, WhiteSourceServerSettings whiteSourceServerSettings) throws HygieiaException;
     Set<String> getAffectedProjectsForOrganization(WhitesourceOrg whitesourceOrg, long historyTimestamp, WhiteSourceServerSettings serverSettings) throws ExecutionException, InterruptedException;
     List<WhiteSourceComponent> getAllProjectsForProduct(WhitesourceOrg whitesourceOrg, WhiteSourceProduct product, WhiteSourceServerSettings serverSettings);
-    void refresh (String orgName, String projectToken);
+    void refresh (String orgName, String projectToken, String altIdentifier);
 }

--- a/src/main/java/com/capitalone/dashboard/controller/DefaultWhiteSourceController.java
+++ b/src/main/java/com/capitalone/dashboard/controller/DefaultWhiteSourceController.java
@@ -8,6 +8,7 @@ import com.capitalone.dashboard.model.WhiteSourceRequest;
 import com.capitalone.dashboard.util.CommonConstants;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,18 +62,15 @@ public class DefaultWhiteSourceController {
     @RequestMapping(value = "/refresh", method = POST,
             consumes = "application/json", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> refresh(@Valid @RequestBody WhiteSourceRefreshRequest request) throws HygieiaException {
-        if (Objects.isNull(request) || Objects.isNull(request.getOrgName())){
-            return ResponseEntity
-                    .status(HttpStatus.BAD_REQUEST)
-                    .body("Required fields are null");
+        if (Objects.isNull(request) || StringUtils.isEmpty(request.getOrgName())){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Required fields are null");
         }
-        else if (Objects.isNull(request.getProjectToken()) && Objects.isNull(request.getAltIdentifier())){
-            return ResponseEntity
-                    .status(HttpStatus.BAD_REQUEST)
-                    .body("Must provide projectToken or altIdentifier");
+        else if (StringUtils.isEmpty(request.getProjectToken()) && StringUtils.isEmpty(request.getAltIdentifier())){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Must provide projectToken or altIdentifier");
         }
+
         defaultWhiteSourceClient.refresh(request.getOrgName(),request.getProjectToken(), request.getAltIdentifier());
-        String res = (Objects.nonNull(request.getProjectToken())) ? ", projectToken="+request.getProjectToken() : ", altIdentifier="+request.getAltIdentifier();
+        String res = StringUtils.isNotEmpty(request.getProjectToken()) ? ", projectToken="+request.getProjectToken() : ", altIdentifier="+request.getAltIdentifier();
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body("Updated Whitesource component:: OrgName="+request.getOrgName()+res);

--- a/src/main/java/com/capitalone/dashboard/controller/DefaultWhiteSourceController.java
+++ b/src/main/java/com/capitalone/dashboard/controller/DefaultWhiteSourceController.java
@@ -61,15 +61,21 @@ public class DefaultWhiteSourceController {
     @RequestMapping(value = "/refresh", method = POST,
             consumes = "application/json", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> refresh(@Valid @RequestBody WhiteSourceRefreshRequest request) throws HygieiaException {
-        if (Objects.isNull(request) ||Objects.isNull(request.getOrgName()) ||Objects.isNull(request.getProjectToken()) ){
+        if (Objects.isNull(request) || Objects.isNull(request.getOrgName())){
             return ResponseEntity
                     .status(HttpStatus.BAD_REQUEST)
                     .body("Required fields are null");
         }
-        defaultWhiteSourceClient.refresh(request.getOrgName(),request.getProjectToken());
+        else if (Objects.isNull(request.getProjectToken()) && Objects.isNull(request.getAltIdentifier())){
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body("Must provide projectToken or altIdentifier");
+        }
+        defaultWhiteSourceClient.refresh(request.getOrgName(),request.getProjectToken(), request.getAltIdentifier());
+        String res = (Objects.nonNull(request.getProjectToken())) ? ", projectToken="+request.getProjectToken() : ", altIdentifier="+request.getAltIdentifier();
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body("Updated Whitesource component:: OrgName="+request.getOrgName()+ ", projectToken="+request.getProjectToken());
+                .body("Updated Whitesource component:: OrgName="+request.getOrgName()+res);
     }
 
 }

--- a/src/main/java/com/capitalone/dashboard/controller/DefaultWhiteSourceController.java
+++ b/src/main/java/com/capitalone/dashboard/controller/DefaultWhiteSourceController.java
@@ -62,18 +62,15 @@ public class DefaultWhiteSourceController {
     @RequestMapping(value = "/refresh", method = POST,
             consumes = "application/json", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> refresh(@Valid @RequestBody WhiteSourceRefreshRequest request) throws HygieiaException {
-        if (Objects.isNull(request) || StringUtils.isEmpty(request.getOrgName())){
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Required fields are null");
-        }
-        else if (StringUtils.isEmpty(request.getProjectToken()) && StringUtils.isEmpty(request.getAltIdentifier())){
+        if (StringUtils.isEmpty(request.getProjectToken()) && StringUtils.isEmpty(request.getAltIdentifier())){
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Must provide projectToken or altIdentifier");
         }
 
-        defaultWhiteSourceClient.refresh(request.getOrgName(),request.getProjectToken(), request.getAltIdentifier());
-        String res = StringUtils.isNotEmpty(request.getProjectToken()) ? ", projectToken="+request.getProjectToken() : ", altIdentifier="+request.getAltIdentifier();
+        defaultWhiteSourceClient.refresh(request.getProjectToken(), request.getAltIdentifier());
+        String res = StringUtils.isNotEmpty(request.getProjectToken()) ? "projectToken="+request.getProjectToken() : "altIdentifier="+request.getAltIdentifier();
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body("Updated Whitesource component:: OrgName="+request.getOrgName()+res);
+                .body("Updated Whitesource component:: " + res);
     }
 
 }

--- a/src/main/java/com/capitalone/dashboard/model/WhiteSourceRefreshRequest.java
+++ b/src/main/java/com/capitalone/dashboard/model/WhiteSourceRefreshRequest.java
@@ -10,8 +10,8 @@ public class WhiteSourceRefreshRequest {
     @ApiModelProperty(notes = "WhiteSource Project name",name="ProjectName")
     private String projectName;
 
-    @ApiModelProperty(notes = "WhiteSource Product name",name="ProductName",required=true)
-    private String productName;
+    @ApiModelProperty(notes = "WhiteSource alternate identifier",name="AltIdentifier",required=false)
+    private String altIdentifier;
 
     @ApiModelProperty(notes = "WhiteSource Project token",name="ProjectToken",required=true)
     private String projectToken;
@@ -32,13 +32,10 @@ public class WhiteSourceRefreshRequest {
         this.projectName = projectName;
     }
 
-    public String getProductName() {
-        return productName;
-    }
 
-    public void setProductName(String productName) {
-        this.productName = productName;
-    }
+    public String getAltIdentifier() {return altIdentifier;}
+
+    public void setAltIdentifier(String altIdentifier) {this.altIdentifier = altIdentifier;}
 
     public String getProjectToken() { return projectToken; }
 

--- a/src/main/java/com/capitalone/dashboard/model/WhiteSourceRefreshRequest.java
+++ b/src/main/java/com/capitalone/dashboard/model/WhiteSourceRefreshRequest.java
@@ -4,6 +4,12 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class WhiteSourceRefreshRequest {
 
+    @ApiModelProperty(notes = "WhiteSource Organization name",name="OrgName",required=false)
+    private String orgName;
+
+    @ApiModelProperty(notes = "WhiteSource Product name",name="ProductName",required=false)
+    private String productName;
+
     @ApiModelProperty(notes = "WhiteSource Project name",name="ProjectName")
     private String projectName;
 
@@ -21,6 +27,14 @@ public class WhiteSourceRefreshRequest {
         this.projectName = projectName;
     }
 
+
+    public String getOrgName() {return orgName;}
+
+    public void setOrgName(String orgName) {this.orgName = orgName;}
+
+    public String getProductName() {return productName;}
+
+    public void setProductName(String productName) {this.productName = productName;}
 
     public String getAltIdentifier() {return altIdentifier;}
 

--- a/src/main/java/com/capitalone/dashboard/model/WhiteSourceRefreshRequest.java
+++ b/src/main/java/com/capitalone/dashboard/model/WhiteSourceRefreshRequest.java
@@ -13,7 +13,7 @@ public class WhiteSourceRefreshRequest {
     @ApiModelProperty(notes = "WhiteSource alternate identifier",name="AltIdentifier",required=false)
     private String altIdentifier;
 
-    @ApiModelProperty(notes = "WhiteSource Project token",name="ProjectToken",required=true)
+    @ApiModelProperty(notes = "WhiteSource Project token",name="ProjectToken",required=false)
     private String projectToken;
 
     public String getOrgName() {

--- a/src/main/java/com/capitalone/dashboard/model/WhiteSourceRefreshRequest.java
+++ b/src/main/java/com/capitalone/dashboard/model/WhiteSourceRefreshRequest.java
@@ -4,9 +4,6 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class WhiteSourceRefreshRequest {
 
-    @ApiModelProperty(notes = "WhiteSource Organization name",name="OrgName",required=true)
-    private String orgName;
-
     @ApiModelProperty(notes = "WhiteSource Project name",name="ProjectName")
     private String projectName;
 
@@ -15,14 +12,6 @@ public class WhiteSourceRefreshRequest {
 
     @ApiModelProperty(notes = "WhiteSource Project token",name="ProjectToken",required=false)
     private String projectToken;
-
-    public String getOrgName() {
-        return orgName;
-    }
-
-    public void setOrgName(String orgName) {
-        this.orgName = orgName;
-    }
 
     public String getProjectName() {
         return projectName;

--- a/src/main/java/com/capitalone/dashboard/repository/WhiteSourceComponentRepository.java
+++ b/src/main/java/com/capitalone/dashboard/repository/WhiteSourceComponentRepository.java
@@ -21,6 +21,6 @@ public interface WhiteSourceComponentRepository extends BaseCollectorItemReposit
     @Query(value="{'collectorId': ?0, 'options.projectToken': ?1}")
     List<CollectorItem> findByCollectorIdAndProjectToken(ObjectId collectorId, String projectToken);
 
-    @Query(value="{'collectorId': ?0, 'altIdentfier': ?1}")
+    @Query(value="{'collectorId': ?0, 'altIdentifier': ?1}")
     List<CollectorItem> findByCollectorIdAndAltIdentifier(ObjectId collectorId, String altIdentifier);
 }

--- a/src/main/java/com/capitalone/dashboard/repository/WhiteSourceComponentRepository.java
+++ b/src/main/java/com/capitalone/dashboard/repository/WhiteSourceComponentRepository.java
@@ -18,4 +18,9 @@ public interface WhiteSourceComponentRepository extends BaseCollectorItemReposit
     @Query("{'options.projectToken' : ?0}")
     List<CollectorItem> findByProjectToken(String projectToken);
 
+    @Query(value="{'collectorId': ?0, 'options.projectToken': ?1}")
+    List<CollectorItem> findByCollectorIdAndProjectToken(ObjectId collectorId, String projectToken);
+
+    @Query(value="{'collectorId': ?0, 'altIdentfier': ?1}")
+    List<CollectorItem> findByCollectorIdAndAltIdentifier(ObjectId collectorId, String altIdentifier);
 }

--- a/src/main/java/com/capitalone/dashboard/utils/Constants.java
+++ b/src/main/java/com/capitalone/dashboard/utils/Constants.java
@@ -10,6 +10,7 @@ public final class Constants {
     public static final String PROJECTS = "projects";
     public static final String PROJECT_NAME = "projectName";
     public static final String PROJECT_TOKEN = "projectToken";
+    public static final String ALT_IDENTIFIER = "altIdentifier";
     public static final String PROJECT_VITALS = "projectVitals";
     public static final String LAST_UPDATED_DATE = "lastUpdatedDate";
     public static final String NAME = "name";


### PR DESCRIPTION
made changes to the refresh process, the white source collector items are now found using either productToken or altIdentifier